### PR TITLE
Add property to enable deleting Kafka topics

### DIFF
--- a/jobs/kafka/spec
+++ b/jobs/kafka/spec
@@ -35,3 +35,7 @@ properties:
       - name: test
         replication_factor: 1
         partitions: 1
+
+  delete_topic:
+    description: "Switch to enable topic deletion or not"
+    default: false

--- a/jobs/kafka/templates/config/server.properties.erb
+++ b/jobs/kafka/templates/config/server.properties.erb
@@ -19,6 +19,9 @@
 # The id of the broker. This must be set to a unique integer for each broker.
 broker.id=<%= spec.index+1 %>
 
+# Switch to enable topic deletion or not, default value is false
+delete.topic.enable=<%= p("delete_topic") %>
+
 ############################# Socket Server Settings #############################
 
 # The address the socket server listens on. It will get the value returned from


### PR DESCRIPTION
If `delete.topic.enable` is `false` (by default), the topics are not deleted on execution of a `delete-topic` command. This PR allows configuring this behavior by enabling a property.