### PR TITLE
Make log data persistent

### DIFF
--- a/jobs/kafka/templates/config/server.properties.erb
+++ b/jobs/kafka/templates/config/server.properties.erb
@@ -56,7 +56,7 @@ socket.request.max.bytes=104857600
 ############################# Log Basics #############################
 
 # A comma seperated list of directories under which to store log files
-log.dirs=/var/vcap/sys/log/kafka
+log.dirs=/var/vcap/store/kafka
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across


### PR DESCRIPTION
the setting `log.dirs` isn't referring to log output but the place where the actual replicated log files are stored. They should be under the persistent `/var/vcap/store/kafka` dir of the BOSH managed persistent disk.